### PR TITLE
Input Simulation Port: Camera

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityCameraInputSimulationProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityCameraInputSimulationProfile.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7393bff647614a449a110d62bca0b16b, type: 3}
+  m_Name: DefaultMixedRealityCameraInputSimulationProfile
+  m_EditorClassIdentifier: 
+  isCustomProfile: 0

--- a/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityCameraInputSimulationProfile.asset.meta
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityCameraInputSimulationProfile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 37cfa7f95b850de49a017cb945b66c44
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityInputSimulationDataProvidersProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/DefaultProfiles/Input/Simulation/DefaultMixedRealityInputSimulationDataProvidersProfile.asset
@@ -13,4 +13,11 @@ MonoBehaviour:
   m_Name: DefaultMixedRealityInputSimulationDataProvidersProfile
   m_EditorClassIdentifier: 
   isCustomProfile: 0
-  registeredInputSimulationDataProviders: []
+  registeredInputSimulationDataProviders:
+  - dataProviderType:
+      reference: XRTK.Providers.InputSystem.Simulation.CameraSimulationDataProvider,
+        XRTK
+    dataProviderName: Camera Input Simulation Data Provider
+    priority: 5
+    runtimePlatform: 1
+    profile: {fileID: 11400000, guid: 37cfa7f95b850de49a017cb945b66c44, type: 2}


### PR DESCRIPTION
## Overview

This PR builds on top of #46 and adds default profiles for camera input simulation as well as an update to the the default input simulation data providers profile to register the camera provider. The related Core PR is https://github.com/XRTK/XRTK-Core/pull/227

## Changes:

- Add default camera provider profile
- Add camera provider to default providers for simulation
