### PR TITLE
Dev/bounding box accessors

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -326,6 +326,8 @@ namespace XRTK.SDK.Input.Handlers
 
         private bool isRotationPossible = false;
 
+        private Vector3 offsetPosition = Vector3.zero;
+
         private Vector3 prevPosition = Vector3.zero;
 
         private Vector3 prevScale = Vector3.one;
@@ -346,7 +348,7 @@ namespace XRTK.SDK.Input.Handlers
         {
             if (isBeingHeld)
             {
-                manipulationTarget.position = primaryPointer.Result.Details.Point;
+                manipulationTarget.position = offsetPosition + primaryPointer.Result.Details.Point;
             }
 
             if (isPressed && isNudgePossible && primaryPointer != null)
@@ -656,6 +658,7 @@ namespace XRTK.SDK.Input.Handlers
             MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(SpatialMeshDisplayOptions.Collision);
 
             prevPosition = manipulationTarget.position;
+            offsetPosition = prevPosition - eventData.Pointer.Result.Details.Point;
             prevScale = manipulationTarget.localScale;
             prevRotation = manipulationTarget.rotation;
 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -658,7 +658,12 @@ namespace XRTK.SDK.Input.Handlers
             MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(SpatialMeshDisplayOptions.Collision);
 
             prevPosition = manipulationTarget.position;
-            offsetPosition = prevPosition - eventData.Pointer.Result.Details.Point;
+
+            if (prevPosition != Vector3.zero)
+            {
+                offsetPosition = prevPosition - eventData.Pointer.Result.Details.Point;
+            }
+
             prevScale = manipulationTarget.localScale;
             prevRotation = manipulationTarget.rotation;
 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.SpatialAwarenessSystem;
 using XRTK.EventDatum.Input;
-using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
 using XRTK.Services;
@@ -126,6 +125,19 @@ namespace XRTK.SDK.Input.Handlers
         [SerializeField]
         [Tooltip("The object to manipulate using this handler. Automatically uses this transform if none is set.")]
         private Transform manipulationTarget;
+
+        [SerializeField]
+        [Tooltip("The spatial mesh visibility while manipulating an object.")]
+        private SpatialMeshDisplayOptions spatialMeshVisibility = SpatialMeshDisplayOptions.Visible;
+
+        /// <summary>
+        /// The spatial mesh visibility while manipulating an object.
+        /// </summary>
+        public SpatialMeshDisplayOptions SpatialMeshVisibility
+        {
+            get => spatialMeshVisibility;
+            set => spatialMeshVisibility = value;
+        }
 
         [SerializeField]
         [Tooltip("Should the user press and hold the select action or press to hold and press again to release?")]
@@ -659,7 +671,7 @@ namespace XRTK.SDK.Input.Handlers
             isBeingHeld = true;
 
             MixedRealityToolkit.InputSystem.PushModalInputHandler(gameObject);
-            MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(SpatialMeshDisplayOptions.Collision);
+            MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(spatialMeshVisibility);
 
             prevPosition = manipulationTarget.position;
 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -8,6 +8,7 @@ using XRTK.EventDatum.Input;
 using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
+using XRTK.SDK.UX;
 using XRTK.Services;
 
 namespace XRTK.SDK.Input.Handlers
@@ -282,9 +283,7 @@ namespace XRTK.SDK.Input.Handlers
         /// <remarks>
         /// Used to determine if the <see cref="GameObject"/> is currently being manipulated by the user.
         /// </remarks>
-        public bool IsBeingHeld => isBeingHeld;
-
-        private bool isBeingHeld = false;
+        public bool IsBeingHeld { get; private set; } = false;
 
         /// <summary>
         /// The updated extent of the pointer.
@@ -309,66 +308,63 @@ namespace XRTK.SDK.Input.Handlers
         /// <summary>
         /// Is the <see cref="primaryInputSource"/> currently pressed?
         /// </summary>
-        public bool IsPressed => isPressed;
-
-        private bool isPressed = false;
+        public bool IsPressed { get; private set; } = false;
 
         /// <summary>
         /// Is there currently a manipulation processing a rotation?
         /// </summary>
-        public bool IsRotating => isRotating;
-
-        private bool isRotating = false;
+        public bool IsRotating { get; private set; } = false;
 
         /// <summary>
         /// Is scaling possible?
         /// </summary>
-        public bool IsScalingPossible => isScalePossible;
-
-        private bool isScalePossible = false;
+        public bool IsScalingPossible { get; private set; } = false;
 
         /// <summary>
         /// Is nudge possible?
         /// </summary>
-        public bool IsNudgePossible => isNudgePossible;
-
-        private bool isNudgePossible = false;
+        public bool IsNudgePossible { get; private set; } = false;
 
         /// <summary>
         /// Is rotation possible?
         /// </summary>
-        public bool IsRotationPossible => isRotationPossible;
-
-        private bool isRotationPossible = false;
-
-        private Vector3 offsetPosition = Vector3.zero;
-
-        private Vector3 prevPosition = Vector3.zero;
+        public bool IsRotationPossible { get; private set; } = false;
 
         private Vector3 prevScale = Vector3.one;
 
+        private Vector3 prevPosition = Vector3.zero;
         private Quaternion prevRotation = Quaternion.identity;
 
+        private Vector3 grabbedPosition = Vector3.zero;
+
+        private BoundingBox boundingBox;
+
         private int prevPhysicsLayer;
+        private int boundingBoxPrevPhysicsLayer;
 
         #region Monobehaviour Implementation
 
-        private void Awake()
+        protected virtual void Awake()
         {
             if (manipulationTarget == null)
             {
                 manipulationTarget = transform;
             }
+
+            boundingBox = GetComponent<BoundingBox>();
         }
 
-        private void Update()
+        protected virtual void Update()
         {
-            if (isBeingHeld)
+            if (IsBeingHeld)
             {
-                manipulationTarget.position = offsetPosition + primaryPointer.Result.Details.Point;
+                if (!IsRotating && !IsScalingPossible)
+                {
+                    manipulationTarget.position = grabbedPosition + primaryPointer.Result.Details.Point;
+                }
             }
 
-            if (isPressed && isNudgePossible && primaryPointer != null)
+            if (IsPressed && IsNudgePossible && primaryPointer != null)
             {
                 primaryPointer.PointerExtent = updatedExtent;
             }
@@ -378,7 +374,7 @@ namespace XRTK.SDK.Input.Handlers
         {
             base.OnDisable();
 
-            if (isBeingHeld)
+            if (IsBeingHeld)
             {
                 EndHold();
             }
@@ -392,7 +388,7 @@ namespace XRTK.SDK.Input.Handlers
         public virtual void OnInputDown(InputEventData eventData)
         {
             if (!eventData.used &&
-                isBeingHeld &&
+                IsBeingHeld &&
                 eventData.MixedRealityInputAction == cancelAction)
             {
                 EndHold(true);
@@ -404,7 +400,7 @@ namespace XRTK.SDK.Input.Handlers
         public virtual void OnInputUp(InputEventData eventData)
         {
             if (!eventData.used &&
-                isBeingHeld &&
+                IsBeingHeld &&
                 eventData.MixedRealityInputAction == cancelAction)
             {
                 EndHold(true);
@@ -415,7 +411,7 @@ namespace XRTK.SDK.Input.Handlers
         /// <inheritdoc />
         public virtual void OnInputChanged(InputEventData<float> eventData)
         {
-            if (!isBeingHeld ||
+            if (!IsBeingHeld ||
                 primaryInputSource == null ||
                 eventData.InputSource.SourceId != primaryInputSource.SourceId)
             {
@@ -425,27 +421,29 @@ namespace XRTK.SDK.Input.Handlers
             if (eventData.MixedRealityInputAction == touchpadPressAction &&
                 eventData.InputData <= 0.00001f)
             {
-                isRotating = false;
+                IsRotating = false;
+                IsNudgePossible = false;
+                IsScalingPossible = false;
                 lastPositionReading.x = 0f;
                 lastPositionReading.y = 0f;
                 eventData.Use();
             }
 
-            if (isRotating) { return; }
+            if (IsRotating) { return; }
 
-            if (!isPressed &&
+            if (!IsPressed &&
                 eventData.MixedRealityInputAction == touchpadPressAction &&
                 eventData.InputData >= pressThreshold)
             {
-                isPressed = true;
+                IsPressed = true;
                 eventData.Use();
             }
 
-            if (isPressed &&
+            if (IsPressed &&
                 eventData.MixedRealityInputAction == touchpadPressAction &&
                 eventData.InputData <= pressThreshold)
             {
-                isPressed = false;
+                IsPressed = false;
                 eventData.Use();
             }
         }
@@ -453,12 +451,18 @@ namespace XRTK.SDK.Input.Handlers
         /// <inheritdoc />
         public virtual void OnInputChanged(InputEventData<Vector2> eventData)
         {
-            if (!isBeingHeld ||
+            // reset this in case we are rotating only.
+            IsScalingPossible = false;
+
+            if (!IsBeingHeld ||
                 primaryInputSource == null ||
+                primaryPointer == null ||
                 eventData.InputSource.SourceId != primaryInputSource.SourceId)
             {
                 return;
             }
+
+            var pointerPosition = primaryPointer.Result.Details.Point;
 
             // Filter our actions
             if (eventData.MixedRealityInputAction != nudgeAction ||
@@ -472,66 +476,73 @@ namespace XRTK.SDK.Input.Handlers
             absoluteInputData.x = Mathf.Abs(absoluteInputData.x);
             absoluteInputData.y = Mathf.Abs(absoluteInputData.y);
 
-            isRotationPossible = eventData.MixedRealityInputAction == rotateAction &&
-                                     (absoluteInputData.x >= rotationZone.x ||
-                                      absoluteInputData.y >= rotationZone.x);
+            IsRotationPossible = eventData.MixedRealityInputAction == rotateAction &&
+                                 (absoluteInputData.x >= rotationZone.x ||
+                                  absoluteInputData.y >= rotationZone.x);
 
-            if (!isPressed &&
-                isRotationPossible &&
+            if (!IsPressed &&
+                IsRotationPossible &&
                 !lastPositionReading.x.Equals(0f) && !lastPositionReading.y.Equals(0f))
             {
                 var rotationAngle = Vector2.SignedAngle(lastPositionReading, eventData.InputData);
 
                 if (Mathf.Abs(rotationAngle) > rotationAngleActivation)
                 {
-                    isRotating = true;
+                    IsRotating = true;
                 }
 
-                if (isRotating)
+                if (IsRotating)
                 {
-                    manipulationTarget.Rotate(0f, -rotationAngle, 0f, Space.Self);
+                    manipulationTarget.position = grabbedPosition + pointerPosition;
+                    manipulationTarget.RotateAround(pointerPosition, Vector3.up, -rotationAngle);
+
+                    if (prevPosition != Vector3.zero)
+                    {
+                        grabbedPosition = manipulationTarget.position - pointerPosition;
+                    }
+
                     eventData.Use();
                 }
             }
 
             lastPositionReading = eventData.InputData;
 
-            if (!isPressed || isRotating) { return; }
+            if (!IsPressed || IsRotating) { return; }
 
-            isScalePossible = eventData.MixedRealityInputAction == scaleAction && absoluteInputData.x > 0f;
-            isNudgePossible = eventData.MixedRealityInputAction == nudgeAction && absoluteInputData.y > 0f && primaryPointer != null;
+            IsScalingPossible = eventData.MixedRealityInputAction == scaleAction && absoluteInputData.x > 0f;
+            IsNudgePossible = eventData.MixedRealityInputAction == nudgeAction && absoluteInputData.y > 0f;
 
             // Check to make sure that input values fall between min/max zone values
-            if (isScalePossible &&
+            if (IsScalingPossible &&
                 (absoluteInputData.x <= scaleZone.x ||
                  absoluteInputData.x >= scaleZone.y))
             {
-                isScalePossible = false;
+                IsScalingPossible = false;
             }
 
             // Check to make sure that input values fall between min/max zone values
-            if (isNudgePossible &&
+            if (IsNudgePossible &&
                 (absoluteInputData.y <= nudgeZone.x ||
                  absoluteInputData.y >= nudgeZone.y))
             {
-                isNudgePossible = false;
+                IsNudgePossible = false;
             }
 
             // Disable any actions if min zone values overlap.
             if (absoluteInputData.x <= scaleZone.x &&
                 absoluteInputData.y <= nudgeZone.x)
             {
-                isNudgePossible = false;
-                isScalePossible = false;
+                IsNudgePossible = false;
+                IsScalingPossible = false;
             }
 
-            if (isScalePossible && isNudgePossible)
+            if (IsScalingPossible && IsNudgePossible)
             {
-                isNudgePossible = false;
-                isScalePossible = false;
+                IsNudgePossible = false;
+                IsScalingPossible = false;
             }
 
-            if (isNudgePossible)
+            if (IsNudgePossible)
             {
                 Debug.Assert(primaryPointer != null);
                 var newExtent = primaryPointer.PointerExtent;
@@ -567,7 +578,7 @@ namespace XRTK.SDK.Input.Handlers
                 eventData.Use();
             }
 
-            if (isScalePossible)
+            if (IsScalingPossible)
             {
                 var newScale = manipulationTarget.localScale;
                 var currentScale = newScale;
@@ -593,15 +604,24 @@ namespace XRTK.SDK.Input.Handlers
                     }
                 }
 
-                manipulationTarget.localScale = newScale;
+                manipulationTarget.position = grabbedPosition + pointerPosition;
+                manipulationTarget.ScaleAround(pointerPosition, newScale);
+
+                if (prevPosition != Vector3.zero)
+                {
+                    grabbedPosition = manipulationTarget.position - pointerPosition;
+                }
+
                 eventData.Use();
             }
         }
 
-        /// <summary>Calculates the extent of the nudge.</summary>
+        /// <summary>
+        /// Calculates the extent of the nudge.
+        /// </summary>
         /// <param name="eventData">The event data.</param>
         /// <param name="prevExtent">The previous extent distance of the pointer and raycast.</param>
-        /// <returns></returns>
+        /// <returns>The new pointer extent.</returns>
         protected virtual float CalculateNudgeDistance(InputEventData<Vector2> eventData, float prevExtent)
         {
             return prevExtent + nudgeAmount * (eventData.InputData.y < 0f ? -1 : 1);
@@ -636,7 +656,7 @@ namespace XRTK.SDK.Input.Handlers
 
             if (useHold)
             {
-                if (isBeingHeld)
+                if (IsBeingHeld)
                 {
                     EndHold();
                 }
@@ -646,7 +666,7 @@ namespace XRTK.SDK.Input.Handlers
                 }
             }
 
-            if (!useHold && isBeingHeld)
+            if (!useHold && IsBeingHeld)
             {
                 EndHold();
             }
@@ -667,22 +687,9 @@ namespace XRTK.SDK.Input.Handlers
         /// <param name="eventData"></param>
         public virtual void BeginHold(MixedRealityPointerEventData eventData)
         {
-            if (isBeingHeld) { return; }
+            if (IsBeingHeld) { return; }
 
-            isBeingHeld = true;
-
-            MixedRealityToolkit.InputSystem.PushModalInputHandler(gameObject);
-            MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(spatialMeshVisibility);
-
-            prevPosition = manipulationTarget.position;
-
-            if (prevPosition != Vector3.zero)
-            {
-                offsetPosition = prevPosition - eventData.Pointer.Result.Details.Point;
-            }
-
-            prevScale = manipulationTarget.localScale;
-            prevRotation = manipulationTarget.rotation;
+            IsBeingHeld = true;
 
             if (primaryInputSource == null)
             {
@@ -694,8 +701,34 @@ namespace XRTK.SDK.Input.Handlers
                 primaryPointer = eventData.Pointer;
             }
 
+            MixedRealityToolkit.InputSystem.PushModalInputHandler(gameObject);
+            MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(spatialMeshVisibility);
+
+            var pointerPosition = primaryPointer.Result.Details.Point;
+
+            prevPosition = manipulationTarget.position;
+
+            if (prevPosition != Vector3.zero)
+            {
+                grabbedPosition = prevPosition - pointerPosition;
+
+                // update the pointer extent to prevent the object from popping to the end of the pointer
+                var currentRaycastDistance = primaryPointer.Result.Details.RayDistance;
+                primaryPointer.PointerExtent = currentRaycastDistance;
+            }
+
+            prevScale = manipulationTarget.localScale;
+            prevRotation = manipulationTarget.rotation;
+
             prevPhysicsLayer = manipulationTarget.gameObject.layer;
             manipulationTarget.SetLayerRecursively(IgnoreRaycastLayer);
+
+            if (boundingBox != null)
+            {
+                boundingBoxPrevPhysicsLayer = boundingBox.gameObject.layer;
+                boundingBox.transform.SetLayerRecursively(IgnoreRaycastLayer);
+            }
+
             eventData.Use();
         }
 
@@ -707,7 +740,7 @@ namespace XRTK.SDK.Input.Handlers
         /// </param>
         public virtual void EndHold(bool isCanceled = false)
         {
-            if (!isBeingHeld) { return; }
+            if (!IsBeingHeld) { return; }
 
             MixedRealityToolkit.SpatialAwarenessSystem.SetMeshVisibility(SpatialMeshDisplayOptions.None);
 
@@ -721,9 +754,15 @@ namespace XRTK.SDK.Input.Handlers
                 manipulationTarget.rotation = prevRotation;
             }
 
-            isBeingHeld = false;
+            IsBeingHeld = false;
             MixedRealityToolkit.InputSystem.PopModalInputHandler();
+
             manipulationTarget.SetLayerRecursively(prevPhysicsLayer);
+
+            if (boundingBox != null)
+            {
+                boundingBox.transform.SetLayerRecursively(boundingBoxPrevPhysicsLayer);
+            }
         }
     }
 }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -8,6 +8,7 @@ using XRTK.EventDatum.Input;
 using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
+using XRTK.SDK.UX;
 using XRTK.Services;
 
 namespace XRTK.SDK.Input.Handlers
@@ -23,6 +24,8 @@ namespace XRTK.SDK.Input.Handlers
         IMixedRealityInputHandler<float>,
         IMixedRealityInputHandler<Vector2>
     {
+        private const int IgnoreRaycastLayer = 2;
+
         #region Input Actions
 
         [Header("Input Actions")]
@@ -169,7 +172,7 @@ namespace XRTK.SDK.Input.Handlers
 
         [SerializeField]
         [Tooltip("The min and max size this object can be scaled to.")]
-        private Vector2 scaleConstraints = new Vector2(0.01f, 1f);
+        private Vector2 scaleConstraints = new Vector2(0.02f, 2f);
 
         /// <summary>
         /// The min and max size this object can be scaled to.
@@ -333,6 +336,8 @@ namespace XRTK.SDK.Input.Handlers
         private Vector3 prevScale = Vector3.one;
 
         private Quaternion prevRotation = Quaternion.identity;
+
+        private int prevPhysicsLayer;
 
         #region Monobehaviour Implementation
 
@@ -677,8 +682,9 @@ namespace XRTK.SDK.Input.Handlers
                 primaryPointer = eventData.Pointer;
             }
 
-            manipulationTarget.SetCollidersActive(false);
-
+            var currentTarget = primaryPointer.Result.CurrentPointerTarget;
+            prevPhysicsLayer = currentTarget.layer;
+            manipulationTarget.SetLayerRecursively(IgnoreRaycastLayer);
             eventData.Use();
         }
 
@@ -706,7 +712,7 @@ namespace XRTK.SDK.Input.Handlers
 
             isBeingHeld = false;
             MixedRealityToolkit.InputSystem.PopModalInputHandler();
-            manipulationTarget.SetCollidersActive(true);
+            manipulationTarget.SetLayerRecursively(prevPhysicsLayer);
         }
     }
 }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.SpatialAwarenessSystem;
 using XRTK.EventDatum.Input;
+using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
 using XRTK.Services;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -8,7 +8,6 @@ using XRTK.EventDatum.Input;
 using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Interfaces.InputSystem.Handlers;
-using XRTK.SDK.UX;
 using XRTK.Services;
 
 namespace XRTK.SDK.Input.Handlers

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -267,7 +267,14 @@ namespace XRTK.SDK.Input.Handlers
         /// <remarks>
         /// Used to determine if the <see cref="GameObject"/> is currently being manipulated by the user.
         /// </remarks>
+        public bool IsBeingHeld => isBeingHeld;
+
         private bool isBeingHeld = false;
+
+        /// <summary>
+        /// The updated extent of the pointer.
+        /// </summary>
+        private float updatedExtent;
 
         /// <summary>
         /// The first input source to start the manipulation phase of this object.
@@ -284,9 +291,40 @@ namespace XRTK.SDK.Input.Handlers
         /// </summary>
         private Vector2 lastPositionReading = Vector2.zero;
 
+        /// <summary>
+        /// Is the <see cref="primaryInputSource"/> currently pressed?
+        /// </summary>
+        public bool IsPressed => isPressed;
+
         private bool isPressed = false;
 
+        /// <summary>
+        /// Is there currently a manipulation processing a rotation?
+        /// </summary>
+        public bool IsRotating => isRotating;
+
         private bool isRotating = false;
+
+        /// <summary>
+        /// Is scaling possible?
+        /// </summary>
+        public bool IsScalingPossible => isScalePossible;
+
+        private bool isScalePossible = false;
+
+        /// <summary>
+        /// Is nudge possible?
+        /// </summary>
+        public bool IsNudgePossible => isNudgePossible;
+
+        private bool isNudgePossible = false;
+
+        /// <summary>
+        /// Is rotation possible?
+        /// </summary>
+        public bool IsRotationPossible => isRotationPossible;
+
+        private bool isRotationPossible = false;
 
         private Vector3 prevPosition = Vector3.zero;
 
@@ -309,6 +347,11 @@ namespace XRTK.SDK.Input.Handlers
             if (isBeingHeld)
             {
                 manipulationTarget.position = primaryPointer.Result.Details.Point;
+            }
+
+            if (isPressed && isNudgePossible && primaryPointer != null)
+            {
+                primaryPointer.PointerExtent = updatedExtent;
             }
         }
 
@@ -410,7 +453,7 @@ namespace XRTK.SDK.Input.Handlers
             absoluteInputData.x = Mathf.Abs(absoluteInputData.x);
             absoluteInputData.y = Mathf.Abs(absoluteInputData.y);
 
-            var isRotationPossible = eventData.MixedRealityInputAction == rotateAction &&
+            isRotationPossible = eventData.MixedRealityInputAction == rotateAction &&
                                      (absoluteInputData.x >= rotationZone.x ||
                                       absoluteInputData.y >= rotationZone.x);
 
@@ -436,8 +479,8 @@ namespace XRTK.SDK.Input.Handlers
 
             if (!isPressed || isRotating) { return; }
 
-            bool isScalePossible = eventData.MixedRealityInputAction == scaleAction && absoluteInputData.x > 0f;
-            bool isNudgePossible = eventData.MixedRealityInputAction == nudgeAction && absoluteInputData.y > 0f;
+            isScalePossible = eventData.MixedRealityInputAction == scaleAction && absoluteInputData.x > 0f;
+            isNudgePossible = eventData.MixedRealityInputAction == nudgeAction && absoluteInputData.y > 0f && primaryPointer != null;
 
             // Check to make sure that input values fall between min/max zone values
             if (isScalePossible &&
@@ -471,44 +514,37 @@ namespace XRTK.SDK.Input.Handlers
 
             if (isNudgePossible)
             {
-                var pointers = eventData.InputSource.Pointers;
+                Debug.Assert(primaryPointer != null);
+                var newExtent = primaryPointer.PointerExtent;
+                var currentRaycastDistance = primaryPointer.Result.Details.RayDistance;
 
-                for (int i = 0; i < pointers.Length; i++)
+                // Reset the cursor extent to the nearest value in case we're hitting something close
+                // and the user wants to adjust. That way it doesn't take forever to see the change.
+                if (currentRaycastDistance < newExtent)
                 {
-                    var newExtent = pointers[i].PointerExtent;
-                    var currentRaycastDistance = pointers[i].Result.Details.RayDistance;
-
-                    // Reset the cursor extent to the nearest value in case we're hitting something close
-                    // and the user wants to adjust. That way it doesn't take forever to see the change.
-                    if (currentRaycastDistance < newExtent)
-                    {
-                        newExtent = currentRaycastDistance;
-                    }
-
-                    var prevExtent = newExtent;
-
-                    if (eventData.InputData.y < 0f)
-                    {
-                        newExtent = prevExtent - nudgeAmount;
-
-                        if (newExtent <= nudgeConstraints.x)
-                        {
-                            newExtent = prevExtent;
-                        }
-                    }
-                    else
-                    {
-                        newExtent = prevExtent + nudgeAmount;
-
-                        if (newExtent >= nudgeConstraints.y)
-                        {
-                            newExtent = prevExtent;
-                        }
-                    }
-
-                    pointers[i].PointerExtent = newExtent;
+                    newExtent = currentRaycastDistance;
                 }
 
+                var prevExtent = newExtent;
+                newExtent = CalculateNudgeDistance(eventData, prevExtent);
+
+                // check constraints
+                if (eventData.InputData.y < 0f)
+                {
+                    if (newExtent <= nudgeConstraints.x)
+                    {
+                        newExtent = prevExtent;
+                    }
+                }
+                else
+                {
+                    if (newExtent >= nudgeConstraints.y)
+                    {
+                        newExtent = prevExtent;
+                    }
+                }
+
+                updatedExtent = newExtent;
                 eventData.Use();
             }
 
@@ -541,6 +577,15 @@ namespace XRTK.SDK.Input.Handlers
                 manipulationTarget.localScale = newScale;
                 eventData.Use();
             }
+        }
+
+        /// <summary>Calculates the extent of the nudge.</summary>
+        /// <param name="eventData">The event data.</param>
+        /// <param name="prevExtent">The previous extent distance of the pointer and raycast.</param>
+        /// <returns></returns>
+        protected virtual float CalculateNudgeDistance(InputEventData<Vector2> eventData, float prevExtent)
+        {
+            return prevExtent + nudgeAmount * (eventData.InputData.y < 0f ? -1 : 1);
         }
 
         #endregion IMixedRealityInputHandler Implementation

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -919,6 +919,9 @@ namespace XRTK.SDK.UX
                 linkRenderer.shadowCastingMode = ShadowCastingMode.Off;
                 linkRenderer.receiveShadows = false;
 
+                var linkCollider = link.GetComponent<Collider>();
+                linkCollider.enabled = false;
+
                 if (wireframeMaterial != null)
                 {
                     linkRenderer.material = wireframeMaterial;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -268,6 +268,7 @@ namespace XRTK.SDK.UX
                 if (displayHandles != value)
                 {
                     displayHandles = value;
+
                     ResetHandleVisibility();
                 }
             }
@@ -392,6 +393,12 @@ namespace XRTK.SDK.UX
                 if (showScaleHandles != value)
                 {
                     showScaleHandles = value;
+
+                    if (value)
+                    {
+                        displayHandles = true;
+                    }
+
                     ResetHandleVisibility();
                 }
             }
@@ -412,6 +419,11 @@ namespace XRTK.SDK.UX
                 if (showRotateHandles != value)
                 {
                     showRotateHandles = value;
+
+                    if (value)
+                    {
+                        displayHandles = true;
+                    }
 
                     showRotationHandlesPerAxis = (CardinalAxis)(!showRotateHandles ? 0 : -1);
 
@@ -436,7 +448,7 @@ namespace XRTK.SDK.UX
                 if (showRotationHandlesPerAxis != value)
                 {
                     showRotationHandlesPerAxis = value;
-                    showRotateHandles = true;
+                    ShowRotateHandles = true;
 
                     ResetHandleVisibility();
                 }
@@ -674,6 +686,7 @@ namespace XRTK.SDK.UX
             {
                 if (cachedTargetCollider != null)
                 {
+                    cachedTargetCollider.size -= wireframePadding;
                     Destroy(cachedTargetCollider);
                 }
             }
@@ -978,27 +991,22 @@ namespace XRTK.SDK.UX
             {
                 cachedTargetCollider = boxColliderToUse;
                 cachedTargetCollider.transform.hasChanged = true;
+                cachedTargetCollider.size += wireframePadding;
             }
             else
             {
                 if (cachedTargetCollider != null)
                 {
+                    cachedTargetCollider.size -= wireframePadding;
                     Destroy(cachedTargetCollider);
                 }
 
                 var bounds = transform.GetColliderBounds();
 
                 cachedTargetCollider = gameObject.AddComponent<BoxCollider>();
-
-                Debug.Assert(!bounds.size.x.Equals(0));
-                Debug.Assert(!bounds.size.y.Equals(0));
-                Debug.Assert(!bounds.size.z.Equals(0));
-
                 cachedTargetCollider.center = transform.InverseTransformPoint(bounds.center);
-                cachedTargetCollider.size = bounds.size / transform.localScale.x;
+                cachedTargetCollider.size = (bounds.size / transform.localScale.x) + wireframePadding;
             }
-
-            cachedTargetCollider.size += wireframePadding;
         }
 
         private void SetMaterials()

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -429,6 +429,7 @@ namespace XRTK.SDK.UX
                 if (showRotationHandlesPerAxis != value)
                 {
                     showRotationHandlesPerAxis = value;
+                    showRotateHandles = true;
 
                     ResetHandleVisibility();
                 }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -545,6 +545,7 @@ namespace XRTK.SDK.UX
                     }
 
                     rigRoot.gameObject.SetActive(value);
+                    cachedTargetCollider.enabled = value;
 
                     if (value)
                     {


### PR DESCRIPTION
## Overview

Added accessors to bounding box to easier customization at runtime.

- Blocked by https://github.com/XRTK/XRTK-Core/pull/261

## Changes

- Fixed handle visibility when using cardinal axes.
- Fixed bounding center not being calculated correctly.
- Added manipulation handler as a required component to the bounding box.
- Disabled colliders on the bounding box and it's proxy as we're performing manipulations.
- Ensure we enabled display handles if setting any of the handle display flags to true
- Fixed wireframe padding growing each time the bounding box was enabled/disabled
- Added spatial mesh visibility options while manipulating an object.
- Now when an object is grabbed it's transformed by that grabbed point (scale, transform, rotation)
    - Handles transform the object from its center pivot