### PR TITLE
dev/focus-cleanup

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Cursors/TeleportCursor.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Cursors/TeleportCursor.cs
@@ -102,11 +102,11 @@ namespace XRTK.SDK.UX.Cursors
                 return;
             }
 
-            if (pointer.Result == null) { return; }
+            if (pointer.Result.Details.Object == null) { return; }
 
             transform.position = pointer.Result.Details.Point;
 
-            Vector3 forward = CameraCache.Main.transform.forward;
+            var forward = CameraCache.Main.transform.forward;
             forward.y = 0f;
 
             // Smooth out rotation just a tad to prevent jarring transitions

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Pointers/LinePointer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Pointers/LinePointer.cs
@@ -116,7 +116,7 @@ namespace XRTK.SDK.UX.Pointers
             // Set our first and last points
             lineBase.FirstPoint = pointerPosition;
 
-            if (!IsFocusLocked || Result == null)
+            if (!IsFocusLocked || Result.Details.Object == null)
             {
                 lineBase.LastPoint = pointerPosition + pointerRotation * Vector3.forward * PointerExtent;
             }
@@ -167,7 +167,7 @@ namespace XRTK.SDK.UX.Pointers
             float cursorOffsetWorldLength = BaseCursor?.SurfaceCursorDistance ?? 0f;
 
             // If we hit something
-            if (Result?.CurrentPointerTarget != null)
+            if (Result.CurrentPointerTarget != null)
             {
                 clearWorldLength = Result.Details.RayDistance;
                 lineColor = IsSelectPressed ? LineColorSelected : LineColorValid;
@@ -196,7 +196,8 @@ namespace XRTK.SDK.UX.Pointers
 
             // If focus is locked, we're sticking to the target
             // So don't clamp the world length
-            if (IsFocusLocked && IsTargetPositionLockedOnFocusLock)
+            if (IsFocusLocked &&
+                IsTargetPositionLockedOnFocusLock)
             {
                 float cursorOffsetLocalLength = LineBase.GetNormalizedLengthFromWorldLength(cursorOffsetWorldLength);
                 LineBase.LineEndClamp = 1 - cursorOffsetLocalLength;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Pointers/TouchPointer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Pointers/TouchPointer.cs
@@ -66,7 +66,10 @@ namespace XRTK.SDK.UX.Pointers
         {
             position = Vector3.zero;
             if (fingerId < 0) { return false; }
-            position = Result?.Details.Point ?? CameraCache.Main.ScreenPointToRay(UnityEngine.Input.GetTouch(FingerId).position).GetPoint(PointerExtent);
+
+            position = Result.Details.Object == null
+                ? CameraCache.Main.ScreenPointToRay(UnityEngine.Input.GetTouch(FingerId).position).GetPoint(PointerExtent)
+                : Result.Details.Point;
             return true;
         }
 


### PR DESCRIPTION
## Overview

Cleaned up usage of `pointer.Result`

## Changes:

- https://github.com/XRTK/XRTK-Core/pull/282
- Removed null checks for `pointer.Result`. This value should never be null.
- misc formatting