### PR TITLE
Fix physics sweeping when not snapped

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -1054,7 +1054,11 @@ namespace XRTK.SDK.Input.Handlers
             {
                 if (!isValidMove)
                 {
-                    targetPosition = currentPosition;
+                    if (IsSnappedToSurface)
+                    {
+                        targetPosition = currentPosition;
+                    }
+
                     isValidSnap = false;
                 }
 


### PR DESCRIPTION
## Overview

Fixed a problem where the manipulated object would stall when the physics sweep happens when we didn't have snap to surface enabled