### PR TITLE
add flag so translation can be locked while rotating: in order to inc…

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -396,10 +396,17 @@ namespace XRTK.SDK.Input.Handlers
         /// </summary>
         public bool IsRotating => !updatedAngle.Equals(0f);
 
+        [SerializeField]
+        [Tooltip("Locks down the ability to change the position of the GameObject.")]
+        private bool isTranslateLocked = false;
+        
         /// <summary>Gets or sets a value indicating whether this instance can be moved in space.</summary>
-        /// <value>
-        ///   <c>true</c> if this instance is translate locked; otherwise, <c>false</c>.</value>
-        public bool IsTranslateLocked { get; set; } = false;
+        /// <value><c>true</c> if this instance is translate locked; otherwise, <c>false</c>.</value>
+        public bool IsTranslateLocked 
+        {
+            get => isTranslateLocked;
+            set => isTranslateLocked = value;
+        }
 
         /// <summary>
         /// Is scaling possible?

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -396,6 +396,11 @@ namespace XRTK.SDK.Input.Handlers
         /// </summary>
         public bool IsRotating => !updatedAngle.Equals(0f);
 
+        /// <summary>Gets or sets a value indicating whether this instance can be moved in space.</summary>
+        /// <value>
+        ///   <c>true</c> if this instance is translate locked; otherwise, <c>false</c>.</value>
+        public bool IsTranslateLocked { get; set; } = false;
+
         /// <summary>
         /// Is scaling possible?
         /// </summary>
@@ -1118,7 +1123,10 @@ namespace XRTK.SDK.Input.Handlers
                 targetPosition = Vector3.Lerp(manipulationTarget.position, targetPosition, Time.deltaTime * smoothingFactor);
             }
 
-            manipulationTarget.position = targetPosition;
+            if (!IsTranslateLocked)
+            {
+                manipulationTarget.position = targetPosition;
+            }
 
             var pivot = pointerGrabPoint == Vector3.zero ? pointerPosition : pointerGrabPoint;
 


### PR DESCRIPTION
…rease precision and eliminate jitteriness.

## Overview

Manipulating rotation, translation and scale at the same time can be awkward. To some extent scale and rotation can be disabled. This property allows translation to be locked under certain circumstances by the developer (for instance, lock down translation during rotation).
