### PR TITLE
Fixed global listener unregistration 

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/InputSystemGlobalListener.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/InputSystemGlobalListener.cs
@@ -44,6 +44,11 @@ namespace XRTK.SDK.Input
             MixedRealityToolkit.InputSystem?.Unregister(gameObject);
         }
 
+        protected virtual void OnDestroy()
+        {
+            MixedRealityToolkit.InputSystem?.Unregister(gameObject);
+        }
+
         protected async Task<bool> ValidateInputSystemAsync()
         {
             try

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Cursors/BaseCursor.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Cursors/BaseCursor.cs
@@ -299,8 +299,9 @@ namespace XRTK.SDK.UX.Cursors
             OnCursorStateChange(CursorStateEnum.Contextual);
         }
 
-        private void OnDestroy()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
             UnregisterManagers();
         }
 


### PR DESCRIPTION
## Overview

Input system global listener sometimes doesn't unregister a global listener if the object is destroyed outright and disable isn't called first
