### PR TITLE
Fix DestroyImmediate being called in editor playmode causing Unity ev…

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ControllerPoseSynchronizer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ControllerPoseSynchronizer.cs
@@ -111,7 +111,7 @@ namespace XRTK.SDK.Input.Handlers
 
                 if (destroyOnSourceLost)
                 {
-                    if (Application.isEditor)
+                    if (Application.isEditor && !Application.isPlaying)
                     {
                         DestroyImmediate(gameObject);
                     }


### PR DESCRIPTION
## Overview

Fixes the issue where Unity MonoBehaviour events are not executed in editor play mode for controller pose synchronizers when they are destroyed.