### PR TITLE
Make input system global listener non abstract

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/InputSystemGlobalListener.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/InputSystemGlobalListener.cs
@@ -12,7 +12,7 @@ namespace XRTK.SDK.Input
     /// <summary>
     /// This component ensures that all input events are forwarded to this <see cref="GameObject"/> when focus or gaze is not required.
     /// </summary>
-    public abstract class InputSystemGlobalListener : MonoBehaviour
+    public class InputSystemGlobalListener : MonoBehaviour
     {
         private bool lateInitialize = true;
 


### PR DESCRIPTION
## Overview

Removed the abstract modifier. This allows to attach `InputSystemGlobalListener` to game objects on its own.

## Changes:

- Resolves: #128 