### PR TITLE
Transform Extension Collider and Bounds Calculation Performance Update

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -482,23 +482,31 @@ namespace XRTK.SDK.Input.Handlers
         {
             get
             {
+                var isSet = false;
+
                 if (BoundingBox != null &&
                     BoundingBox.BoundingBoxCollider != null)
                 {
-                    return BoundingBox.BoundingBoxCollider;
+                    thisCollider = BoundingBox.BoundingBoxCollider;
+                    isSet = true;
                 }
 
                 if (thisCollider == null)
                 {
                     thisCollider = gameObject.GetComponent<Collider>();
+                    isSet = true;
                 }
 
                 if (thisCollider == null)
                 {
                     thisCollider = gameObject.EnsureComponent<BoxCollider>();
+                    isSet = true;
                 }
 
-                transform.GetColliderBounds();
+                if (isSet)
+                {
+                    transform.GetColliderBounds(ref cachedColliders);
+                }
 
                 return thisCollider;
             }
@@ -556,6 +564,7 @@ namespace XRTK.SDK.Input.Handlers
         private float snappedVerticalPosition;
 
         private Transform snapTarget;
+        private Collider[] cachedColliders;
 
         #region Monobehaviour Implementation
 
@@ -896,8 +905,7 @@ namespace XRTK.SDK.Input.Handlers
             }
 
             PrimaryPointer.OverrideGrabPoint = grabOffset;
-
-            transform.SetCollidersActive(false);
+            transform.SetCollidersActive(false, ref cachedColliders);
             Collider.enabled = true;
             body.isKinematic = false;
 
@@ -935,7 +943,7 @@ namespace XRTK.SDK.Input.Handlers
 
             MixedRealityToolkit.InputSystem?.PopModalInputHandler();
 
-            transform.SetCollidersActive(true);
+            transform.SetCollidersActive(true, ref cachedColliders);
 
             body.isKinematic = true;
 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -905,6 +905,7 @@ namespace XRTK.SDK.Input.Handlers
             }
 
             PrimaryPointer.OverrideGrabPoint = grabOffset;
+            transform.GetColliderBounds(ref cachedColliders);
             transform.SetCollidersActive(false, ref cachedColliders);
             Collider.enabled = true;
             body.isKinematic = false;
@@ -943,9 +944,9 @@ namespace XRTK.SDK.Input.Handlers
 
             MixedRealityToolkit.InputSystem?.PopModalInputHandler();
 
-            transform.SetCollidersActive(true, ref cachedColliders);
-
             body.isKinematic = true;
+
+            transform.SetCollidersActive(true, ref cachedColliders);
 
             PrimaryPointer.SyncedTarget = null;
             PrimaryPointer.OverrideGrabPoint = null;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/Handlers/ManipulationHandler.cs
@@ -905,7 +905,6 @@ namespace XRTK.SDK.Input.Handlers
             }
 
             PrimaryPointer.OverrideGrabPoint = grabOffset;
-            transform.GetColliderBounds(ref cachedColliders);
             transform.SetCollidersActive(false, ref cachedColliders);
             Collider.enabled = true;
             body.isKinematic = false;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/BoundingBox/BoundingBox.cs
@@ -52,6 +52,9 @@ namespace XRTK.SDK.UX
 
             private int cachedTargetPrevLayer;
 
+            private Collider[] colliderCache;
+            private Collider[] parentColliderCache;
+
             /// <inheritdoc />
             void IMixedRealityPointerHandler.OnPointerDown(MixedRealityPointerEventData eventData)
             {
@@ -81,8 +84,8 @@ namespace XRTK.SDK.UX
                     cachedTargetPrevLayer = BoundingBoxParent.BoundingBoxCollider.gameObject.layer;
                     BoundingBoxParent.BoundingBoxCollider.transform.SetLayerRecursively(IgnoreRaycastLayer);
                     BoundingBoxParent.BoundingBoxCollider.enabled = false;
-                    BoundingBoxParent.transform.SetCollidersActive(false);
-                    transform.SetCollidersActive(false);
+                    BoundingBoxParent.transform.SetCollidersActive(false, ref parentColliderCache);
+                    transform.SetCollidersActive(false, ref colliderCache);
                     BoundingBoxParent.BoundingBoxCollider.enabled = true;
                     BoundingBoxParent.isManipulationEnabled = true;
                     eventData.Use();
@@ -103,8 +106,8 @@ namespace XRTK.SDK.UX
                     BoundingBoxParent.ResetHandleVisibility();
                     MixedRealityToolkit.InputSystem.PopModalInputHandler();
                     BoundingBoxParent.BoundingBoxCollider.transform.SetLayerRecursively(cachedTargetPrevLayer);
-                    BoundingBoxParent.transform.SetCollidersActive(true);
-                    transform.SetCollidersActive(true);
+                    BoundingBoxParent.transform.SetCollidersActive(true, ref parentColliderCache);
+                    transform.SetCollidersActive(true, ref colliderCache);
                     eventData.Use();
                 }
             }
@@ -552,6 +555,8 @@ namespace XRTK.SDK.UX
 
         private Vector3[] boundsCorners = new Vector3[8];
 
+        private Collider[] colliderCache;
+
         /// <summary>
         /// The current bounds corner positions.
         /// </summary>
@@ -994,7 +999,7 @@ namespace XRTK.SDK.UX
                 transform.rotation = Quaternion.identity;
                 Physics.SyncTransforms(); // Update collider bounds
 
-                var bounds = transform.GetColliderBounds(false);
+                var bounds = transform.GetColliderBounds(ref colliderCache, false);
 
                 BoundingBoxCollider = gameObject.AddComponent<BoxCollider>();
 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/package.json
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/package.json
@@ -12,7 +12,7 @@
   "src": "Assets/XRTK.Core",
   "author": "XRTK Team (https://github.com/XRTK)",
   "dependencies": {
-    "com.xrtk.core": "0.1.28",
+    "com.xrtk.core": "0.1.30",
     "com.unity.textmeshpro": "1.0.0"
   }
 }

--- a/XRTK.SDK/Packages/manifest.json
+++ b/XRTK.SDK/Packages/manifest.json
@@ -12,7 +12,7 @@
     "com.unity.package-manager-ui": "2.1.2",
     "com.unity.textmeshpro": "2.0.1",
     "com.unity.xr.legacyinputhelpers": "2.0.6",
-    "com.xrtk.core": "0.1.28",
+    "com.xrtk.core": "0.1.30",
     "com.xrtk.lumin": "0.1.10",
     "com.xrtk.oculus": "0.1.11",
     "com.xrtk.wmr": "0.1.9",


### PR DESCRIPTION
## Overview

Continuation of https://github.com/XRTK/XRTK-Core/pull/448

## Changes:

- update all the usages of `Transform.SetCollidersActive`
- only update transform bounds if collider is set