### PR TITLE
Scene helper script addition - Create Starting scene elements

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Diagnostics/Prefabs/DefaultDiagnosticsWindow.prefab
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Diagnostics/Prefabs/DefaultDiagnosticsWindow.prefab
@@ -285,8 +285,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: '{PackageID} v{Package Version}'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -798,8 +798,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Peak: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1718,8 +1718,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Used: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1896,8 +1896,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Limit: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2708,8 +2708,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'CPU: 00 fps (00.00ms)'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2955,8 +2955,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'GPU: 00 fps (00.00ms)'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 0}
-  m_sharedMaterial: {fileID: 0}
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Diagnostics/Prefabs/DefaultDiagnosticsWindow.prefab
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Diagnostics/Prefabs/DefaultDiagnosticsWindow.prefab
@@ -285,8 +285,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: '{PackageID} v{Package Version}'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -798,8 +798,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Peak: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1718,8 +1718,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Used: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1896,8 +1896,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'Limit: 00.00MB'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2708,8 +2708,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'CPU: 00 fps (00.00ms)'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2955,8 +2955,8 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_text: 'GPU: 00 fps (00.00ms)'
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 0}
+  m_sharedMaterial: {fileID: 0}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor.meta
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c6b3a6772a54de40a7df6bb84049555
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
@@ -14,10 +14,15 @@ namespace XRTK.SDK.UX.Utilities
         [MenuItem("Mixed Reality Toolkit/Tools/SDK/Create Floor", false, 1)]
         public static void CreateFloor()
         {
-            var sceneRoot = new GameObject("Scene Objects");
-            var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
-            floor.name = "Ground";
-            floor.transform.SetParent(sceneRoot.transform);
+            //check if there is already a Scene Objects GO
+            var sceneRoot = GameObject.Find("Scene Objects");
+            if(!sceneRoot)
+            {
+                sceneRoot = new GameObject("Scene Objects");
+                var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+                floor.name = "Ground";
+                floor.transform.SetParent(sceneRoot.transform);
+            }
         }
     }
 }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using UnityEditor;

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace XRTK.SDK.UX.Utilities
+{
+    public class SceneHelpers
+    {
+        /// <summary>
+        /// Simple scene helper to create the beginnings of a scene, creating the scene root and a floor.
+        /// </summary>
+        [MenuItem("Mixed Reality Toolkit/Tools/SDK/Create Floor", false, 1)]
+        public static void CreateFloor()
+        {
+            var sceneRoot = new GameObject("Scene Objects");
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            floor.name = "Ground";
+            floor.transform.SetParent(sceneRoot.transform);
+        }
+    }
+}

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs.meta
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/SceneHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6449917b6643dd4ba8b0c29208243e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 08c0fd91bdca45afa09ec64323cf3848, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef
@@ -1,3 +1,15 @@
-﻿{
-	"name": "XRTK.SDK.Utilities.Editor"
+{
+    "name": "XRTK.SDK.Utilities.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "XRTK.SDK.Utilities.Editor"
+}

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef.meta
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Editor/XRTK.SDK.Utilities.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: efa14be8d8c43594fb9ed6ca48122e9f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview

Added the first scene helper, a simple editor script to add the following:

* Scene Root - Scene Objects empty gameobject
* Floor - Plane primitive

This will be extremely useful for testing and new projects to get going quickly

## Additional Notes

Also updated the Diagnostics prefab as Unity updated it on startup.  Will see if this new version (no changes) resolves the package load issue.
