### PR TITLE
Fix/hand joint positions

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Controllers/Hands/BaseHandControllerVisualizer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Controllers/Hands/BaseHandControllerVisualizer.cs
@@ -113,8 +113,8 @@ namespace XRTK.SDK.UX.Controllers.Hands
                 {
                     var jointTransform = GetOrCreateJointTransform(handJoint);
                     var jointPose = jointPoses[handJoint];
-                    jointTransform.position = jointPose.Position;
-                    jointTransform.rotation = jointPose.Rotation;
+                    jointTransform.localPosition = jointPose.Position;
+                    jointTransform.localRotation = jointPose.Rotation;
                 }
             }
         }

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Controllers/Hands/HandControllerJointsVisualizer.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/UX/Scripts/Controllers/Hands/HandControllerJointsVisualizer.cs
@@ -31,6 +31,7 @@ namespace XRTK.SDK.UX.Controllers.Hands
         [Tooltip("Material tint color for index fingertip.")]
         private Color indexFingertipColor = Color.cyan;
 
+        /// <inheritdoc />
         public override void OnInputChanged(InputEventData<HandData> eventData)
         {
             base.OnInputChanged(eventData);


### PR DESCRIPTION
## Overview

When playing with the Camera Refactor I noticed that the hands for Magic Leap didn't follow the camera correctly. I realized that in the base controller visualizar, the pose position is a local position, so I took a look at the hand joint positions and saw we were setting their world position, I knew immediately we should probably update this to use the local position. 

Now hands work after we teleport! 🎉 