### PR TITLE
Fixed a NRE when the GazeProvider doesn't have a parent

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/GazeProvider.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Features/Input/GazeProvider.cs
@@ -189,8 +189,17 @@ namespace XRTK.SDK.Input
                 {
                     stabilizer.UpdateStability(gazeTransform.localPosition, gazeTransform.localRotation * Vector3.forward);
                     var transformParent = gazeTransform.parent;
-                    newGazeOrigin = transformParent.TransformPoint(stabilizer.StablePosition);
-                    newGazeNormal = transformParent.TransformDirection(stabilizer.StableRay.direction);
+
+                    if (transformParent != null)
+                    {
+                        newGazeOrigin = transformParent.TransformPoint(stabilizer.StablePosition);
+                        newGazeNormal = transformParent.TransformDirection(stabilizer.StableRay.direction);
+                    }
+                    else
+                    {
+                        newGazeOrigin = gazeTransform.TransformPoint(stabilizer.StablePosition);
+                        newGazeNormal = gazeTransform.TransformDirection(stabilizer.StableRay.direction);
+                    }
                 }
 
                 Vector3 endPoint = newGazeOrigin + (newGazeNormal * pointerExtent);


### PR DESCRIPTION
## Overview

When running the XRTK without a camera system, the Main Camera is no longer parented under the Mixed Reality Playspace. If the Input System is on, then it'll throw Null Refs. 
