### PR TITLE
SDK package installer prefab copy fix

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Editor/SDKPackageInstaller.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Editor/SDKPackageInstaller.cs
@@ -44,7 +44,7 @@ namespace XRTK.SDK.Editor
 
             if (!EditorPreferences.Get($"{nameof(SDKPackageInstaller)}.Prefabs", false))
             {
-                EditorPreferences.Set($"{nameof(SDKPackageInstaller)}.Prefabs", PackageInstaller.TryInstallAssets(HiddenPrefabPath, $"{DefaultPath}\\Prefabs"));
+                EditorPreferences.Set($"{nameof(SDKPackageInstaller)}.Prefabs", PackageInstaller.TryInstallAssets(HiddenPrefabPath, $"{DefaultPath}\\Prefabs", "prefab"));
             }
         }
     }


### PR DESCRIPTION
Updated SDK Package installer to also install prefabs with the extension of "prefab"

## Overview

High level overview of this pull request.

## Changes:

- Fixes: #172

## Requires

- Core\#569
