### PR TITLE
Remove XRTK prefix from SDK package installer

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Editor/SDKPackageInstaller.cs
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Editor/SDKPackageInstaller.cs
@@ -27,13 +27,13 @@ namespace XRTK.SDK.Editor
             EditorApplication.delayCall += CheckPackage;
         }
 
-        [MenuItem("Mixed Reality Toolkit/Packages/Install XRTK.SDK Package Assets...", true, -1)]
+        [MenuItem("Mixed Reality Toolkit/Packages/Install SDK Package Assets...", true, -1)]
         private static bool ImportPackageAssetsValidation()
         {
             return !Directory.Exists($"{DefaultPath}\\Profiles") || !Directory.Exists($"{DefaultPath}\\Prefabs");
         }
 
-        [MenuItem("Mixed Reality Toolkit/Packages/Install XRTK.SDK Package Assets...", false, -1)]
+        [MenuItem("Mixed Reality Toolkit/Packages/Install SDK Package Assets...", false, -1)]
         private static void ImportPackageAssets()
         {
             EditorPreferences.Set($"{nameof(SDKPackageInstaller)}.Assets", false);


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Just removed the "XRTK." prefix from the SDK package installer for consistency with all other platforms.

![capture_import_sdk_assets](https://user-images.githubusercontent.com/9565734/100134103-fc1aa780-2e87-11eb-81d0-6a0f51ce519b.PNG)

