### PR TITLE
Clean up grip related input actions

### DIFF
--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/GenericOpenVRController/Left/GripTriggerPositionProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/GenericOpenVRController/Left/GripTriggerPositionProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/GenericOpenVRController/Right/GripTriggerPositionProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/GenericOpenVRController/Right/GripTriggerPositionProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/CommonInteractionMappingProfiles/LeftHandGripInteractionMappingProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/CommonInteractionMappingProfiles/LeftHandGripInteractionMappingProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 16
-      description: Grip
+      description: Grip Press
       axisConstraint: 2
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/CommonInteractionMappingProfiles/RightHandGripInteractionMappingProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/CommonInteractionMappingProfiles/RightHandGripInteractionMappingProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 16
-      description: Grip
+      description: Grip Press
       axisConstraint: 2
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/Simulated/RightSimulatedMixedRealityHandControllerProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/HandControllers/Simulated/RightSimulatedMixedRealityHandControllerProfile.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 1fd0c5cd50876514bb0027af902ed920, type: 2}
   - {fileID: 11400000, guid: 118d8e619c1393b49bbf1d387651668c, type: 2}
   - {fileID: 11400000, guid: ff17201622b23b64f8065fd2e8a79b5a, type: 2}
-  - {fileID: 11400000, guid: ff17201622b23b64f8065fd2e8a79b5a, type: 2}
+  - {fileID: 11400000, guid: 31223e437c1f97a498a229666eb1d6e2, type: 2}
   - {fileID: 11400000, guid: 5e2b50bb0283a7a46aa1cb475066855f, type: 2}
   - {fileID: 11400000, guid: 65fe769960045eb4284e122669355d0f, type: 2}
   - {fileID: 11400000, guid: 7a31aa9670c8b0046ab22a9a8c86aabd, type: 2}

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Left/Axis1D.PrimaryHandTriggerPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Left/Axis1D.PrimaryHandTriggerPressProfile.asset
@@ -18,10 +18,10 @@ MonoBehaviour:
     axisType: 2
     inputType: 13
     inputAction:
-      profileGuid: 00000000000000000000000000000000
-      id: 0
-      description: None
-      axisConstraint: 0
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 16
+      description: Grip Press
+      axisConstraint: 2
     keyCode: 0
     inputName: LHandTrigger
     axisCodeX: AXIS_11

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Left/Axis1D.PrimaryHandTriggerProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Left/Axis1D.PrimaryHandTriggerProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: LHandTrigger

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Right/Axis1D.SecondaryHandTriggerPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Right/Axis1D.SecondaryHandTriggerPressProfile.asset
@@ -18,10 +18,10 @@ MonoBehaviour:
     axisType: 2
     inputType: 13
     inputAction:
-      profileGuid: 00000000000000000000000000000000
-      id: 0
-      description: None
-      axisConstraint: 0
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
+      id: 16
+      description: Grip Press
+      axisConstraint: 2
     keyCode: 0
     inputName: RHandTrigger
     axisCodeX: AXIS_12

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Right/Axis1D.SecondaryHandTriggerProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/OculusTouchController/Right/Axis1D.SecondaryHandTriggerProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: RHandTrigger

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/ViveWandController/Left/GripPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/ViveWandController/Left/GripPressProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/ViveWandController/Right/GripPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/ViveWandController/Right/GripPressProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/WindowsMixedRealityController/Left/GripPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/WindowsMixedRealityController/Left/GripPressProfile.asset
@@ -18,9 +18,9 @@ MonoBehaviour:
     axisType: 3
     inputType: 13
     inputAction:
-      profileGuid: 1f6893f98bc96dd47b9e70e4ff211ed7
+      profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/WindowsMixedRealityController/Right/GripPressProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/DataProviders/WindowsMixedRealityController/Right/GripPressProfile.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     inputAction:
       profileGuid: 399335ccc89c4d12b79f3539ca7771db
       id: 7
-      description: Grip Press
+      description: Grip Strength
       axisConstraint: 3
     keyCode: 0
     inputName: 

--- a/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/MixedRealityInputActionsProfile.asset
+++ b/XRTK.SDK/Packages/com.xrtk.sdk/Profiles~/Input/MixedRealityInputActionsProfile.asset
@@ -22,10 +22,6 @@ MonoBehaviour:
     description: Menu
     axisConstraint: 2
   - profileGuid: 399335ccc89c4d12b79f3539ca7771db
-    id: 3
-    description: Grip Pose
-    axisConstraint: 7
-  - profileGuid: 399335ccc89c4d12b79f3539ca7771db
     id: 4
     description: Pointer Pose
     axisConstraint: 7
@@ -36,10 +32,6 @@ MonoBehaviour:
   - profileGuid: 399335ccc89c4d12b79f3539ca7771db
     id: 6
     description: Trigger
-    axisConstraint: 3
-  - profileGuid: 399335ccc89c4d12b79f3539ca7771db
-    id: 7
-    description: Grip Press
     axisConstraint: 3
   - profileGuid: 399335ccc89c4d12b79f3539ca7771db
     id: 8
@@ -74,6 +66,14 @@ MonoBehaviour:
     description: Index Finger Pose
     axisConstraint: 7
   - profileGuid: 399335ccc89c4d12b79f3539ca7771db
+    id: 7
+    description: Grip Strength
+    axisConstraint: 3
+  - profileGuid: 399335ccc89c4d12b79f3539ca7771db
     id: 16
-    description: Grip
+    description: Grip Press
     axisConstraint: 2
+  - profileGuid: 399335ccc89c4d12b79f3539ca7771db
+    id: 3
+    description: Grip Pose
+    axisConstraint: 7


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

There was some inconsistency with grip related input actions, which I cleaned up. Also I updated all existing and supported controllers to use the now properly named grip input actions. From now on there shall be 3 grip related input actions:

- Grip Press: Digital, has the grip button been pressed to its full extend or not?
- Grip Pose: 6DoF, where to attach things I grabbed using the controller?
- Grip Strength: Single Axis, how strong is my grip?

## Submodule Changes

- [Lumin](https://github.com/XRTK/Lumin/pull/92)
- [Oculus](https://github.com/XRTK/Oculus/pull/98)
- [WMR](https://github.com/XRTK/WindowsMixedReality/pull/110)
- [Examples](https://github.com/XRTK/Examples/pull/18)
